### PR TITLE
Correction of Typo: Challenge in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Social Tables Apprentice Challlenge
+# Social Tables Apprentice Challenge
 
 Our help page <http://help.socialtables.com/> needs help! Your challenge is to write **test coverage** so tablers can sleep better at night knowing customers have access to the help they need.
 


### PR DESCRIPTION
Corrected typo in README.md header: Challenge was spelled "Challlenge".
- [ ] The same typo is also on the Github repositories' description. This was uneditable from my end.
